### PR TITLE
Suggestion: separate names of parameters and auxiliary variables

### DIFF
--- a/booth_bose.ode
+++ b/booth_bose.ode
@@ -4,15 +4,15 @@
 ## |||#|||
 # parameter values
 par ip0=0.75
-# par gLs=0.1  gLd=0.1  gNa=0  gKdr=0  gCa=0  gKahp=0  gKC=0
-par gLs=0.1  gLd=0.1  gNa=30  gKdr=15  gCa=10  gKahp=0.8  gKC=15  
+# par gLs=0.1  gLd=0.1  gNa=0  gKdr=0  gCa=0  gKahp=0  par_gKC=0
+par gLs=0.1  gLd=0.1  gNa=30  gKdr=15  gCa=10  gKahp=0.8  par_gKC=15  
 par VNa=60  VCa=80  VK=-75  VL=-60  Vsyn=0  
 par gc=2.1 pp=0.5  Cm=3  
 par alphac=2 betac=0.1
 # output cols are t, ODEs, AUXs in order, here:
 # t vs vd cad hs ns sd cd qd gqk gkc 
 Vs'=(-gLs*(Vs-VL)-gNa*(Minfs(Vs)^2)*hs*(Vs-VNa)-gKdr*ns*(Vs-VK)+(gc/pp)*(Vd-Vs)+Ip0/pp)/Cm
-Vd'=(-gLd*(Vd-VL)-ICad-gKahp*qd*(Vd-VK)-gKC*cd*chid*(Vd-VK)+(gc*(Vs-Vd))/(1.0-pp))/Cm
+Vd'=(-gLd*(Vd-VL)-ICad-gKahp*qd*(Vd-VK)-par_gKC*cd*chid*(Vd-VK)+(gc*(Vs-Vd))/(1.0-pp))/Cm
 Cad'=  -0.13*ICad-0.075*Cad
 hs'=  alphahs(Vs)-(alphahs(Vs)+betahs(Vs))*hs
 ns'=  alphans(Vs)-(alphans(Vs)+betans(Vs))*ns
@@ -39,7 +39,7 @@ chid=     min(Cad/250.0,1.0)
 # aux sdc =  (gc/pp)*(Vd-Vs)
 # aux ICa = ICad
 aux gkq = gKahp*qd
-aux gkc = gKC*cd*chid
+aux gkc = par_gKC*cd*chid
 # initial conditions
 init Vs=-60 Vd=-60
 # integrator params


### PR DESCRIPTION
XPP raises warning `GKC is a duplicate name`